### PR TITLE
Staging

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Add project root to sys.path so absolute imports work in Streamlit Cloud
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 import requests
 import streamlit as st
 

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from contextlib import redirect_stdout
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+# Ensure project root is in sys.path when running as a script
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 import joblib
 


### PR DESCRIPTION
## Summary

**What changed?**
- Fixed a critical `ModuleNotFoundError` that prevents the app from booting in Streamlit Cloud.
- Dynamically appended the project root to `sys.path` at the top of `frontend/app.py`. This ensures that absolute imports from `frontend.*`, `api.*`, and `src.*` resolve correctly when Streamlit executes the file in isolation.
- Applied the same path resolution fix to `src/models/train.py` to allow direct execution of the model training script via standard python execution without throwing import errors.

## Workstream

- [ ] Data / ML
- [ ] Backend API
- [x] Frontend / UX
- [x] Docs / project setup

## Verification

- [ ] Tests pass
- [x] Manual check completed
- [ ] Not applicable

Commands or checks run:

```text
python src/models/train.py
streamlit run frontend/app.py
