### PR TITLE
Remove 'Still on Treatment' from prediction targets — censored histor…

### DIFF
--- a/src/models/predict.py
+++ b/src/models/predict.py
@@ -19,7 +19,8 @@ TREATMENT_OUTCOME_LABELS = (
     "Treatment Success",
     "Died",
     "Lost to Follow Up",
-    "Still on Treatment",
+    # "Still on Treatment" excluded: this is a censored historical observation,
+    # not a valid prediction class for a new patient intake.
 )
 
 FEATURE_ORDER = (
@@ -137,16 +138,15 @@ def predict_patient_risk(patient: dict[str, object]) -> PredictionResult:
     ltfu_risk = 11 / 183
     poor_outcome_risk = min(1.0, mortality + ltfu_risk)
     success_probability = max(0.0, 1.0 - poor_outcome_risk)
-    still_on_treatment_probability = 18 / 183
 
-    probabilities = {
-        "Treatment Success": round(success_probability, 4),
-        "Died": round(mortality, 4),
-        "Lost to Follow Up": round(ltfu_risk, 4),
-        "Still on Treatment": round(still_on_treatment_probability, 4),
+    # Normalised over the three valid outcome classes only.
+    raw = {
+        "Treatment Success": success_probability,
+        "Died": mortality,
+        "Lost to Follow Up": ltfu_risk,
     }
-    total = sum(probabilities.values())
-    probabilities = {key: round(value / total, 4) for key, value in probabilities.items()}
+    total = sum(raw.values())
+    probabilities = {k: round(v / total, 4) for k, v in raw.items()}
 
     predicted_outcome = max(probabilities, key=probabilities.get)
     return PredictionResult(

--- a/src/models/train.py
+++ b/src/models/train.py
@@ -80,23 +80,42 @@ class TrainingResult:
     model_version: str
 
 
-def normalize_outcome(outcome: str) -> str:
-    """Map paper outcome labels to application outcome classes."""
+# Target outcome classes — mirrors the paper's evaluated outcomes.
+# "Still on Treatment" is excluded: these are censored observations (outcome not
+# yet determined, predominantly incomplete 2021 records). Including them would
+# add a fourth class that is neither a success nor a failure, degrading model signal.
+# Three clinically meaningful prediction targets (excludes censored records).
+TARGET_OUTCOME_CLASSES = ["Treatment Success", "Died", "Lost to Follow Up"]
+
+
+def normalize_outcome(outcome: str) -> str | None:
+    """Map paper outcome labels to the three evaluated outcome classes.
+
+    Returns None for 'Still on Treatment': these are censored observations
+    (outcome not yet determined). It makes no clinical sense to predict this
+    class for a new patient, so they are excluded from training.
+    """
     if outcome in {"Cured", "Treatment Completed", "Treatment Success"}:
         return "Treatment Success"
     if outcome == "Lost to Follow Up":
         return "Lost to Follow Up"
     if outcome == "Died":
         return "Died"
-    return "Still on Treatment"
+    return None  # Still on Treatment = censored, not a valid prediction class
 
 
 def prepare_training_frame(df: pd.DataFrame) -> pd.DataFrame:
-    """Prepare the project dataset for model training."""
+    """Prepare the project dataset for model training.
+
+    Drops 'Still on Treatment' rows before training — these are censored
+    observations (predominantly incomplete 2021 records per the paper).
+    """
     prepared = add_binary_outcomes(df)
     prepared[OUTCOME_TARGET_COLUMN] = prepared["outcome"].map(normalize_outcome)
-    if prepared[OUTCOME_TARGET_COLUMN].isna().any():
-        raise ValueError("training data contains unsupported outcome labels")
+    n_censored = prepared[OUTCOME_TARGET_COLUMN].isna().sum()
+    if n_censored > 0:
+        print(f"  Dropping {n_censored} censored 'Still on Treatment' rows.")
+        prepared = prepared.dropna(subset=[OUTCOME_TARGET_COLUMN]).copy()
     return prepared
 
 


### PR DESCRIPTION
…ical records, not valid for new patient intake

## Summary

What changed?

## Workstream

- [ ] Data / ML
- [ ] Backend API
- [ ] Frontend / UX
- [ ] Docs / project setup

## Verification

- [ ] Tests pass
- [ ] Manual check completed
- [ ] Not applicable

Commands or checks run:

```text

```

## Clinical Safety Checklist

- [ ] No real patient data committed
- [ ] No secrets committed
- [ ] Model or clinical behavior changes include validation notes
- [ ] Output remains explainable to a clinician

## Target Branch

This PR should target `staging`, not `main`.
